### PR TITLE
Fix to comments parsing loop.

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ module.exports = buf => {
   const instructions = readStringByteSizeOfInteger();
   const commentsLen = readInt();
   const comments = [];
-  for (let i = 0; i < comments; i++) {
+  for (let i = 0; i < commentsLen; i++) {
     comments.push(readStringByteSizeOfInteger());
   }
 


### PR DESCRIPTION
Hi,

I noticed whilst porting this code to C++ that the comments loop doesn't use the previously parsed commentsLen integer. Hope this helps, thanks.

Regards,
Phil